### PR TITLE
Filter for currently running EC2 instances only

### DIFF
--- a/internal/awsdata/ec2.go
+++ b/internal/awsdata/ec2.go
@@ -27,7 +27,16 @@ func (d *AWSData) loadEC2Instances(region string) {
 		"service": ServiceEC2,
 	})
 	log.Info("loading instance data")
-	out, err := ec2Svc.DescribeInstances(&ec2.DescribeInstancesInput{})
+	out, err := ec2Svc.DescribeInstances(&ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("instance-state-name"),
+				Values: []*string{
+					aws.String("running"),
+				},
+			},
+		},
+	})
 	if err != nil {
 		d.results <- result{Err: err}
 		return

--- a/internal/awsdata/ec2.go
+++ b/internal/awsdata/ec2.go
@@ -33,6 +33,8 @@ func (d *AWSData) loadEC2Instances(region string) {
 				Name: aws.String("instance-state-name"),
 				Values: []*string{
 					aws.String("running"),
+					aws.String("stopping"),
+					aws.String("stopped"),
 				},
 			},
 		},


### PR DESCRIPTION
EC2 inventory should only contain actually running instances, not instances that may be in some other state (such as recently terminated). Add a filter to ensure that only instances with a current state of "running" are collected.