### PR TITLE
Add support for ALBs and NLBs via the ELBV2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage of ./awsinventory:
   -o, --output-file string   path to the output file (default "inventory.csv")
       --print-regions        prints the available AWS regions
   -r, --regions strings      regions to gather data from
-  -s, --services strings     services to gather data from (default [ebs,ec2,elb,iam,rds,s3])
+  -s, --services strings     services to gather data from (default [ebs,ec2,elb,elbv2,iam,rds,s3])
   -v, --version              prints the version information
 ```
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/aws/aws-sdk-go v1.19.17 h1:m2YqPyQrvx8f4ExpcVGb2PVAchxTkTU2KtKqXvsEqJ
 github.com/aws/aws-sdk-go v1.19.17/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.31.9 h1:n+b34ydVfgC30j0Qm69yaapmjejQPW2BoDBX7Uy/tLI=
 github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.32.5 h1:Sz0C7deIoMu5lFGTVkIN92IEZrUz1AWIDDW+9p6n1Rk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/awsdata/clients.go
+++ b/internal/awsdata/clients.go
@@ -7,6 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -21,6 +23,7 @@ import (
 type Clients interface {
 	GetEC2Client(region string) ec2iface.EC2API
 	GetELBClient(region string) elbiface.ELBAPI
+	GetELBV2Client(region string) elbv2iface.ELBV2API
 	GetIAMClient(region string) iamiface.IAMAPI
 	GetRDSClient(region string) rdsiface.RDSAPI
 	GetRoute53Client(region string) route53iface.Route53API
@@ -38,6 +41,11 @@ func (c DefaultClients) GetEC2Client(region string) ec2iface.EC2API {
 // GetELBClient returns a new ELB client for the given region
 func (c DefaultClients) GetELBClient(region string) elbiface.ELBAPI {
 	return elb.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+}
+
+// GetELBV2Client returns a new ELBV2 client for the given region
+func (c DefaultClients) GetELBV2Client(region string) elbv2iface.ELBV2API {
+	return elbv2.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
 }
 
 // GetIAMClient returns a new IAM client for the given region

--- a/internal/awsdata/clients_test.go
+++ b/internal/awsdata/clients_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
@@ -16,6 +17,7 @@ var testError = errors.New("test aws error")
 type TestClients struct {
 	EC2     ec2iface.EC2API
 	ELB     elbiface.ELBAPI
+	ELBV2   elbv2iface.ELBV2API
 	IAM     iamiface.IAMAPI
 	RDS     rdsiface.RDSAPI
 	Route53 route53iface.Route53API
@@ -32,6 +34,10 @@ func (c TestClients) GetIAMClient(region string) iamiface.IAMAPI {
 
 func (c TestClients) GetELBClient(region string) elbiface.ELBAPI {
 	return c.ELB
+}
+
+func (c TestClients) GetELBV2Client(region string) elbv2iface.ELBV2API {
+	return c.ELBV2
 }
 
 func (c TestClients) GetRDSClient(region string) rdsiface.RDSAPI {

--- a/internal/awsdata/data.go
+++ b/internal/awsdata/data.go
@@ -18,6 +18,8 @@ var (
 		"us-east-1",
 		"us-west-1",
 		"us-west-2",
+		"af-south-1",
+		"ap-east-1",
 		"ap-south-1",
 		"ap-northeast-3",
 		"ap-northeast-2",
@@ -30,9 +32,13 @@ var (
 		"eu-central-1",
 		"eu-west-1",
 		"eu-west-2",
+		"eu-south-1",
 		"eu-west-3",
 		"eu-north-1",
+		"me-south-1",
 		"sa-east-1",
+		"us-gov-east-1",
+		"us-gov-west-1",
 	}
 
 	// ValidServices contains a list of valid AWS services to gather data from
@@ -40,6 +46,7 @@ var (
 		ServiceEBS,
 		ServiceEC2,
 		ServiceELB,
+		ServiceELBV2,
 		ServiceIAM,
 		ServiceRDS,
 		ServiceS3,
@@ -138,6 +145,11 @@ func (d *AWSData) Load(regions, services []string) {
 			go d.loadELBs(region)
 		}
 
+		if stringInSlice(ServiceELBV2, services) {
+			d.wg.Add(1)
+			go d.loadELBV2s(region)
+		}
+
 		if stringInSlice(ServiceRDS, services) {
 			d.wg.Add(1)
 			go d.loadRDSInstances(region)
@@ -224,7 +236,7 @@ func stringInSlice(needle string, haystack []string) bool {
 
 func hasRegionalServices(services []string) bool {
 	for _, service := range services {
-		if service == ServiceEBS || service == ServiceEC2 || service == ServiceELB {
+		if service == ServiceEBS || service == ServiceEC2 || service == ServiceELB || service == ServiceELBV2 {
 			return true
 		}
 	}

--- a/internal/awsdata/elb.go
+++ b/internal/awsdata/elb.go
@@ -33,10 +33,18 @@ func (d *AWSData) loadELBs(region string) {
 
 	log.Info("processing data")
 	for _, l := range out.LoadBalancerDescriptions {
+		var public bool
+		if aws.StringValue(l.Scheme) == "internet-facing" {
+			public = true
+		} else if aws.StringValue(l.Scheme) == "internal" {
+			public = false
+		}
+
 		d.results <- result{
 			Row: inventory.Row{
 				UniqueAssetIdentifier: aws.StringValue(l.LoadBalancerName),
 				Virtual:               true,
+				Public:                public,
 				DNSNameOrURL:          aws.StringValue(l.DNSName),
 				Location:              region,
 				AssetType:             AssetTypeELB,

--- a/internal/awsdata/elb_test.go
+++ b/internal/awsdata/elb_test.go
@@ -18,6 +18,7 @@ var testELBRows = []inventory.Row{
 	{
 		UniqueAssetIdentifier: "abcdefgh12345678",
 		Virtual:               true,
+		Public:                true,
 		DNSNameOrURL:          "abcdefgh12345678.ValidRegions[0].elb.amazonaws.com",
 		Location:              ValidRegions[0],
 		AssetType:             AssetTypeELB,
@@ -27,6 +28,7 @@ var testELBRows = []inventory.Row{
 	{
 		UniqueAssetIdentifier: "12345678abcdefgh",
 		Virtual:               true,
+		Public:                true,
 		DNSNameOrURL:          "12345678abcdefgh.ValidRegions[0].elb.amazonaws.com",
 		Location:              ValidRegions[0],
 		AssetType:             AssetTypeELB,
@@ -36,6 +38,7 @@ var testELBRows = []inventory.Row{
 	{
 		UniqueAssetIdentifier: "a1b2c3d4e5f6g7h8",
 		Virtual:               true,
+		Public:                false,
 		DNSNameOrURL:          "a1b2c3d4e5f6g7h8.ValidRegions[0].elb.amazonaws.com",
 		Location:              ValidRegions[0],
 		AssetType:             AssetTypeELB,
@@ -51,18 +54,21 @@ var testELBOutput = &elb.DescribeLoadBalancersOutput{
 			LoadBalancerName:        aws.String(testELBRows[0].UniqueAssetIdentifier),
 			CanonicalHostedZoneName: aws.String(testELBRows[0].Function),
 			DNSName:                 aws.String(testELBRows[0].DNSNameOrURL),
+			Scheme:                  aws.String("internet-facing"),
 			VPCId:                   aws.String(testELBRows[0].VLANNetworkID),
 		},
 		{
 			LoadBalancerName:        aws.String(testELBRows[1].UniqueAssetIdentifier),
 			CanonicalHostedZoneName: aws.String(testELBRows[1].Function),
 			DNSName:                 aws.String(testELBRows[1].DNSNameOrURL),
+			Scheme:                  aws.String("internet-facing"),
 			VPCId:                   aws.String(testELBRows[1].VLANNetworkID),
 		},
 		{
 			LoadBalancerName:        aws.String(testELBRows[2].UniqueAssetIdentifier),
 			CanonicalHostedZoneName: aws.String(testELBRows[2].Function),
 			DNSName:                 aws.String(testELBRows[2].DNSNameOrURL),
+			Scheme:                  aws.String("internal"),
 			VPCId:                   aws.String(testELBRows[2].VLANNetworkID),
 		},
 	},

--- a/internal/awsdata/elbv2.go
+++ b/internal/awsdata/elbv2.go
@@ -1,0 +1,67 @@
+package awsdata
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/manywho/awsinventory/internal/inventory"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// AssetTypeALB is the value used in the AssetType field when fetching ALBs
+	AssetTypeALB string = "ALB"
+
+	// AssetTypeNLB is the value used in the AssetType field when fetching NLBs
+	AssetTypeNLB string = "NLB"
+
+	// ServiceELBv2 is the key for the ELBV2 service
+	ServiceELBV2 string = "elbv2"
+)
+
+func (d *AWSData) loadELBV2s(region string) {
+	defer d.wg.Done()
+
+	elbv2Svc := d.clients.GetELBV2Client(region)
+
+	log := d.log.WithFields(logrus.Fields{
+		"region":  region,
+		"service": ServiceELBV2,
+	})
+	log.Info("loading data")
+	out, err := elbv2Svc.DescribeLoadBalancers(&elbv2.DescribeLoadBalancersInput{})
+	if err != nil {
+		d.results <- result{Err: err}
+		return
+	}
+
+	log.Info("processing data")
+	for _, l := range out.LoadBalancers {
+		var assettype string
+		if aws.StringValue(l.Type) == "application" {
+			assettype = AssetTypeALB
+		} else if aws.StringValue(l.Type) == "network" {
+			assettype = AssetTypeNLB
+		}
+
+		var public bool
+		if aws.StringValue(l.Scheme) == "internet-facing" {
+			public = true
+		} else if aws.StringValue(l.Scheme) == "internal" {
+			public = false
+		}
+
+		d.results <- result{
+			Row: inventory.Row{
+				UniqueAssetIdentifier: aws.StringValue(l.LoadBalancerName),
+				Virtual:               true,
+				Public:                public,
+				DNSNameOrURL:          aws.StringValue(l.DNSName),
+				Location:              region,
+				AssetType:             assettype,
+				VLANNetworkID:         aws.StringValue(l.VpcId),
+			},
+		}
+	}
+
+	log.Info("finished processing data")
+}

--- a/internal/awsdata/elbv2_test.go
+++ b/internal/awsdata/elbv2_test.go
@@ -1,0 +1,114 @@
+package awsdata_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/manywho/awsinventory/internal/awsdata"
+	"github.com/manywho/awsinventory/internal/inventory"
+)
+
+var testELBV2Rows = []inventory.Row{
+	{
+		UniqueAssetIdentifier: "abcdefgh12345678",
+		Virtual:               true,
+		Public:                true,
+		DNSNameOrURL:          "abcdefgh12345678.ValidRegions[0].elb.amazonaws.com",
+		Location:              ValidRegions[0],
+		AssetType:             AssetTypeALB,
+		VLANNetworkID:         "vpc-abcdefgh",
+	},
+	{
+		UniqueAssetIdentifier: "12345678abcdefgh",
+		Virtual:               true,
+		Public:                true,
+		DNSNameOrURL:          "12345678abcdefgh.ValidRegions[0].elb.amazonaws.com",
+		Location:              ValidRegions[0],
+		AssetType:             AssetTypeNLB,
+		VLANNetworkID:         "vpc-12345678",
+	},
+	{
+		UniqueAssetIdentifier: "a1b2c3d4e5f6g7h8",
+		Virtual:               true,
+		Public:                false,
+		DNSNameOrURL:          "a1b2c3d4e5f6g7h8.ValidRegions[0].elb.amazonaws.com",
+		Location:              ValidRegions[0],
+		AssetType:             AssetTypeALB,
+		VLANNetworkID:         "vpc-a1b2c3d4",
+	},
+}
+
+// Test Data
+var testELBV2Output = &elbv2.DescribeLoadBalancersOutput{
+	LoadBalancers: []*elbv2.LoadBalancer{
+		{
+			LoadBalancerName:        aws.String(testELBV2Rows[0].UniqueAssetIdentifier),
+			DNSName:                 aws.String(testELBV2Rows[0].DNSNameOrURL),
+			Type:                    aws.String("application"),
+			Scheme:                  aws.String("internet-facing"),
+			VpcId:                   aws.String(testELBV2Rows[0].VLANNetworkID),
+		},
+		{
+			LoadBalancerName:        aws.String(testELBV2Rows[1].UniqueAssetIdentifier),
+			DNSName:                 aws.String(testELBV2Rows[1].DNSNameOrURL),
+			Type:                    aws.String("network"),
+			Scheme:                  aws.String("internet-facing"),
+			VpcId:                   aws.String(testELBV2Rows[1].VLANNetworkID),
+		},
+		{
+			LoadBalancerName:        aws.String(testELBV2Rows[2].UniqueAssetIdentifier),
+			DNSName:                 aws.String(testELBV2Rows[2].DNSNameOrURL),
+			Type:                    aws.String("application"),
+			Scheme:                  aws.String("internal"),
+			VpcId:                   aws.String(testELBV2Rows[2].VLANNetworkID),
+		},
+	},
+}
+
+// Mocks
+type ELBV2Mock struct {
+	elbv2iface.ELBV2API
+}
+
+func (e ELBV2Mock) DescribeLoadBalancers(cfg *elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error) {
+	return testELBV2Output, nil
+}
+
+type ELBV2ErrorMock struct {
+	elbv2iface.ELBV2API
+}
+
+func (e ELBV2ErrorMock) DescribeLoadBalancers(cfg *elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error) {
+	return &elbv2.DescribeLoadBalancersOutput{}, testError
+}
+
+// Tests
+func TestCanLoadELBV2s(t *testing.T) {
+	d := New(logrus.New(), TestClients{ELBV2: ELBV2Mock{}})
+
+	d.Load([]string{ValidRegions[0]}, []string{ServiceELBV2})
+
+	var count int
+	d.MapRows(func(row inventory.Row) error {
+		require.Equal(t, testELBV2Rows[count], row)
+		count++
+		return nil
+	})
+	require.Equal(t, 3, count)
+}
+
+func TestLoadELBV2sLogsError(t *testing.T) {
+	logger, hook := logrustest.NewNullLogger()
+
+	d := New(logger, TestClients{ELBV2: ELBV2ErrorMock{}})
+
+	d.Load([]string{ValidRegions[0]}, []string{ServiceELBV2})
+
+	require.Contains(t, hook.LastEntry().Message, testError.Error())
+}


### PR DESCRIPTION
Currently, only classic ELBs were inventoried. Now all ELB types (classic, application, and network load balancers) will be included.

Additionally, add several missing AWS regions.