### PR TITLE
Various improvements, including pagination support and additional columns for some resources

### DIFF
--- a/internal/awsdata/data.go
+++ b/internal/awsdata/data.go
@@ -114,11 +114,6 @@ func (d *AWSData) Load(regions, services []string) {
 		go d.loadIAMUsers()
 	}
 
-	if stringInSlice(ServiceS3, services) {
-		d.wg.Add(1)
-		go d.loadS3Buckets()
-	}
-
 	// Regional Services
 	for _, region := range regions {
 		if stringInSlice(ServiceEC2, services) {
@@ -159,6 +154,11 @@ func (d *AWSData) Load(regions, services []string) {
 		if stringInSlice(ServiceRDS, services) {
 			d.wg.Add(1)
 			go d.loadRDSInstances(region)
+		}
+
+		if stringInSlice(ServiceS3, services) {
+			d.wg.Add(1)
+			go d.loadS3Buckets(region)
 		}
 	}
 
@@ -264,19 +264,12 @@ func AppendIfMissing(slice []string, s string) []string {
 }
 
 func hasRegionalServices(services []string) bool {
-	var regionalServices = []string{
-		ServiceEBS,
-		ServiceEC2,
-		ServiceECS,
-		ServiceElastiCache,
-		ServiceElasticsearchService,
-		ServiceELB,
-		ServiceELBV2,
-		ServiceRDS,
+	var globalServices = []string{
+		ServiceIAM,
 	}
 
 	for _, service := range services {
-		if stringInSlice(service, regionalServices) {
+		if !stringInSlice(service, globalServices) {
 			return true
 		}
 	}

--- a/internal/awsdata/ebs_test.go
+++ b/internal/awsdata/ebs_test.go
@@ -17,27 +17,33 @@ import (
 var testEBSVolumeRows = []inventory.Row{
 	{
 		UniqueAssetIdentifier: "vol-12345678",
-		Location:              DefaultRegion + "-1a",
+		Virtual:               true,
+		Location:              DefaultRegion,
 		AssetType:             AssetTypeEBSVolume,
 		HardwareMakeModel:     "gp2 (100GB)",
 		Function:              "test app 1",
+		SerialAssetTagNumber:  "arn:aws:ec2:us-east-1:012345678910:volume/vol-12345678",
 	},
 	{
 		UniqueAssetIdentifier: "vol-abcdefgh",
-		Location:              DefaultRegion + "-1b",
+		Virtual:               true,
+		Location:              DefaultRegion,
 		AssetType:             AssetTypeEBSVolume,
 		HardwareMakeModel:     "gp2 (50GB)",
+		SerialAssetTagNumber:  "arn:aws:ec2:us-east-1:012345678910:volume/vol-abcdefgh",
 	},
 	{
 		UniqueAssetIdentifier: "vol-a1b2c3d4",
-		Location:              DefaultRegion + "-1c",
+		Virtual:               true,
+		Location:              DefaultRegion,
 		AssetType:             AssetTypeEBSVolume,
 		HardwareMakeModel:     "gp2 (20GB)",
+		SerialAssetTagNumber:  "arn:aws:ec2:us-east-1:012345678910:volume/vol-a1b2c3d4",
 	},
 }
 
 // Test Data
-var testEBSVolumesOutput = &ec2.DescribeVolumesOutput{
+var testEBSDescribeVolumesOutput = &ec2.DescribeVolumesOutput{
 	Volumes: []*ec2.Volume{
 		{
 			VolumeId:         aws.String(testEBSVolumeRows[0].UniqueAssetIdentifier),
@@ -56,14 +62,12 @@ var testEBSVolumesOutput = &ec2.DescribeVolumesOutput{
 			},
 		},
 		{
-
 			VolumeId:         aws.String(testEBSVolumeRows[1].UniqueAssetIdentifier),
 			VolumeType:       aws.String("gp2"),
 			AvailabilityZone: aws.String(testEBSVolumeRows[1].Location),
 			Size:             aws.Int64(50),
 		},
 		{
-
 			VolumeId:         aws.String(testEBSVolumeRows[2].UniqueAssetIdentifier),
 			VolumeType:       aws.String("gp2"),
 			AvailabilityZone: aws.String(testEBSVolumeRows[2].Location),
@@ -77,12 +81,20 @@ type EBSMock struct {
 	ec2iface.EC2API
 }
 
+func (e EBSMock) DescribeSecurityGroups(cfg *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	return testEC2DescribeSecurityGroupsOutput, nil
+}
+
 func (e EBSMock) DescribeVolumes(cfg *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
-	return testEBSVolumesOutput, nil
+	return testEBSDescribeVolumesOutput, nil
 }
 
 type EBSErrorMock struct {
 	ec2iface.EC2API
+}
+
+func (e EBSErrorMock) DescribeSecurityGroups(cfg *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	return &ec2.DescribeSecurityGroupsOutput{}, testError
 }
 
 func (e EBSErrorMock) DescribeVolumes(cfg *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {

--- a/internal/awsdata/ecs.go
+++ b/internal/awsdata/ecs.go
@@ -30,7 +30,9 @@ func (d *AWSData) loadECSContainers(region string) {
 		"region":  region,
 		"service": ServiceECS,
 	})
-	log.Info("loading instance data")
+
+	log.Info("loading data")
+
 	var clusterArns []*string
 	done := false
 	params := &ecs.ListClustersInput{}
@@ -59,7 +61,8 @@ func (d *AWSData) loadECSContainers(region string) {
 		return
 	}
 
-	log.Info("processing instance data")
+	log.Info("processing data")
+
 	for _, cluster := range out.Clusters {
 		var taskArns []*string
 		done := false
@@ -86,7 +89,7 @@ func (d *AWSData) loadECSContainers(region string) {
 		// TODO: API call can only handle 100 task ARNs at a time
 		outDescribeTasks, err := ecsSvc.DescribeTasks(&ecs.DescribeTasksInput{
 			Cluster: cluster.ClusterArn,
-			Tasks: taskArns,
+			Tasks:   taskArns,
 		})
 		if err != nil {
 			d.results <- result{Err: err}
@@ -100,7 +103,7 @@ func (d *AWSData) loadECSContainers(region string) {
 		}
 	}
 
-	log.Info("finished processing instance data")
+	log.Info("finished processing data")
 }
 
 func (d *AWSData) processECSContainer(container *ecs.Container, task *ecs.Task, cluster *ecs.Cluster, ec2Svc ec2iface.EC2API, region string) {
@@ -117,13 +120,13 @@ func (d *AWSData) processECSContainer(container *ecs.Container, task *ecs.Task, 
 		for _, details := range attachment.Details {
 			switch aws.StringValue(details.Name) {
 			case "privateIPv4Address":
-			  ips = append(ips, aws.StringValue(details.Value))
+				ips = append(ips, aws.StringValue(details.Value))
 			case "ipv6Address":
-			  ips = append(ips, aws.StringValue(details.Value))
+				ips = append(ips, aws.StringValue(details.Value))
 			case "macAddress":
-			  macAddresses = append(macAddresses, aws.StringValue(details.Value))
+				macAddresses = append(macAddresses, aws.StringValue(details.Value))
 			case "networkInterfaceId":
-			  networkInterfaces = append(networkInterfaces, aws.StringValue(details.Value))
+				networkInterfaces = append(networkInterfaces, aws.StringValue(details.Value))
 			}
 		}
 	}

--- a/internal/awsdata/ecs_test.go
+++ b/internal/awsdata/ecs_test.go
@@ -17,56 +17,56 @@ import (
 
 var testECSContainerRows = []inventory.Row{
 	{
-		UniqueAssetIdentifier:          "test-container-1-b026324c6904b2a9cb4b88d6d61c81d1-1234567890",
-		IPv4orIPv6Address:              "10.1.2.3\n172.16.4.5\n",
-		Virtual:                        true,
-		MACAddress:                     "ab:cd:ef:00:11:22",
-		BaselineConfigurationName:      "987654321012.dkr.ecr.us-east-2.amazonaws.com/app-1:latest",
-		Location:                       DefaultRegion,
-		AssetType:                      "ECS Container",
-		HardwareMakeModel:              "FARGATE 1.4.0",
-		Function:                       "ecs-cluster-1 service:ecs-service-1",
-		SerialAssetTagNumber:           "arn:aws:ecs:us-east-2:123456789101:container/c73cb0a0-1ee7-4b38-af84-27054f83322e",
-		VLANNetworkID:                  "vpc-123456789",
+		UniqueAssetIdentifier:     "test-container-1-b026324c6904b2a9cb4b88d6d61c81d1-1234567890",
+		IPv4orIPv6Address:         "10.1.2.3\n172.16.4.5\n",
+		Virtual:                   true,
+		MACAddress:                "ab:cd:ef:00:11:22",
+		BaselineConfigurationName: "987654321012.dkr.ecr.us-east-2.amazonaws.com/app-1:latest",
+		Location:                  DefaultRegion,
+		AssetType:                 "ECS Container",
+		HardwareMakeModel:         "FARGATE 1.4.0",
+		Function:                  "ecs-cluster-1 service:ecs-service-1",
+		SerialAssetTagNumber:      "arn:aws:ecs:us-east-2:123456789101:container/c73cb0a0-1ee7-4b38-af84-27054f83322e",
+		VLANNetworkID:             "vpc-123456789",
 	},
 	{
-		UniqueAssetIdentifier:          "test-container-2-b026324c6904b2a9cb4b88d6d61c81d1-2468101214",
-		IPv4orIPv6Address:              "10.1.2.3",
-		Virtual:                        true,
-		MACAddress:                     "ab:cd:ef:00:11:22",
-		BaselineConfigurationName:      "987654321012.dkr.ecr.us-east-2.amazonaws.com/app-2:latest",
-		Location:                       DefaultRegion,
-		AssetType:                      "ECS Container",
-		HardwareMakeModel:              "FARGATE 1.4.0",
-		Function:                       "ecs-cluster-1 service:ecs-service-1",
-		SerialAssetTagNumber:           "arn:aws:ecs:us-east-2:123456789101:container/80966f57-f6ff-4c95-a38b-e9da670c8bdf",
-		VLANNetworkID:                  "vpc-123456789",
+		UniqueAssetIdentifier:     "test-container-2-b026324c6904b2a9cb4b88d6d61c81d1-2468101214",
+		IPv4orIPv6Address:         "10.1.2.3",
+		Virtual:                   true,
+		MACAddress:                "ab:cd:ef:00:11:22",
+		BaselineConfigurationName: "987654321012.dkr.ecr.us-east-2.amazonaws.com/app-2:latest",
+		Location:                  DefaultRegion,
+		AssetType:                 "ECS Container",
+		HardwareMakeModel:         "FARGATE 1.4.0",
+		Function:                  "ecs-cluster-1 service:ecs-service-1",
+		SerialAssetTagNumber:      "arn:aws:ecs:us-east-2:123456789101:container/80966f57-f6ff-4c95-a38b-e9da670c8bdf",
+		VLANNetworkID:             "vpc-123456789",
 	},
 	{
-		UniqueAssetIdentifier:          "test-container-3-26ab0db90d72e28ad0ba1e22ee510510-1234567890",
-		IPv4orIPv6Address:              "10.9.8.7\n10.100.250.25\n",
-		Virtual:                        true,
-		MACAddress:                     "ab:00:cd:11:ef:22",
-		BaselineConfigurationName:      "987654321012.dkr.ecr.us-east-2.amazonaws.com/app-3:latest",
-		Location:                       DefaultRegion,
-		AssetType:                      "ECS Container",
-		HardwareMakeModel:              "EC2",
-		Function:                       "ecs-cluster-1 service:ecs-service-2",
-		SerialAssetTagNumber:           "arn:aws:ecs:us-east-2:123456789101:container/71eaafe1-94ae-4e91-92fb-3c97ec4d63c5",
-		VLANNetworkID:                  "vpc-123456789",
+		UniqueAssetIdentifier:     "test-container-3-26ab0db90d72e28ad0ba1e22ee510510-1234567890",
+		IPv4orIPv6Address:         "10.9.8.7\n10.100.250.25\n",
+		Virtual:                   true,
+		MACAddress:                "ab:00:cd:11:ef:22",
+		BaselineConfigurationName: "987654321012.dkr.ecr.us-east-2.amazonaws.com/app-3:latest",
+		Location:                  DefaultRegion,
+		AssetType:                 "ECS Container",
+		HardwareMakeModel:         "EC2",
+		Function:                  "ecs-cluster-1 service:ecs-service-2",
+		SerialAssetTagNumber:      "arn:aws:ecs:us-east-2:123456789101:container/71eaafe1-94ae-4e91-92fb-3c97ec4d63c5",
+		VLANNetworkID:             "vpc-123456789",
 	},
 	{
-		UniqueAssetIdentifier:          "test-container-4-6d7fce9fee471194aa8b5b6e47267f03-1234567890",
-		IPv4orIPv6Address:              "192.168.0.1\n10.200.10.1\n",
-		Virtual:                        true,
-		MACAddress:                     "fe:99:dc:88:ba:77",
-		BaselineConfigurationName:      "987654321012.dkr.ecr.us-east-2.amazonaws.com/app-4:latest",
-		Location:                       DefaultRegion,
-		AssetType:                      "ECS Container",
-		HardwareMakeModel:              "FARGATE LATEST",
-		Function:                       "ecs-cluster-1 service:ecs-service-3",
-		SerialAssetTagNumber:           "arn:aws:ecs:us-east-2:123456789101:container/3c77e658-9049-46c1-9352-53b59d97f0ac",
-		VLANNetworkID:                  "vpc-123456789",
+		UniqueAssetIdentifier:     "test-container-4-6d7fce9fee471194aa8b5b6e47267f03-1234567890",
+		IPv4orIPv6Address:         "192.168.0.1\n10.200.10.1\n",
+		Virtual:                   true,
+		MACAddress:                "fe:99:dc:88:ba:77",
+		BaselineConfigurationName: "987654321012.dkr.ecr.us-east-2.amazonaws.com/app-4:latest",
+		Location:                  DefaultRegion,
+		AssetType:                 "ECS Container",
+		HardwareMakeModel:         "FARGATE LATEST",
+		Function:                  "ecs-cluster-1 service:ecs-service-3",
+		SerialAssetTagNumber:      "arn:aws:ecs:us-east-2:123456789101:container/3c77e658-9049-46c1-9352-53b59d97f0ac",
+		VLANNetworkID:             "vpc-123456789",
 	},
 }
 
@@ -80,7 +80,7 @@ var testECSListClustersOutput = &ecs.ListClustersOutput{
 var testECSDescribeClustersOutput = &ecs.DescribeClustersOutput{
 	Clusters: []*ecs.Cluster{
 		{
-			ClusterArn: aws.String("arn:aws:ecs:us-east-2:123456789101:cluster/ecs-cluster-1"),
+			ClusterArn:  aws.String("arn:aws:ecs:us-east-2:123456789101:cluster/ecs-cluster-1"),
 			ClusterName: aws.String("ecs-cluster-1"),
 		},
 	},
@@ -102,15 +102,15 @@ var testECSDescribeTasksOutput = &ecs.DescribeTasksOutput{
 					Type: aws.String("ElasticNetworkInterface"),
 					Details: []*ecs.KeyValuePair{
 						{
-							Name: aws.String("networkInterfaceId"),
+							Name:  aws.String("networkInterfaceId"),
 							Value: aws.String("eni-12345678"),
 						},
 						{
-							Name: aws.String("macAddress"),
+							Name:  aws.String("macAddress"),
 							Value: aws.String("ab:cd:ef:00:11:22"),
 						},
 						{
-							Name: aws.String("privateIPv4Address"),
+							Name:  aws.String("privateIPv4Address"),
 							Value: aws.String("10.1.2.3"),
 						},
 					},
@@ -119,8 +119,8 @@ var testECSDescribeTasksOutput = &ecs.DescribeTasksOutput{
 			Containers: []*ecs.Container{
 				{
 					ContainerArn: aws.String(testECSContainerRows[0].SerialAssetTagNumber),
-					Name: aws.String("test-container-1"),
-					Image: aws.String(testECSContainerRows[0].BaselineConfigurationName),
+					Name:         aws.String("test-container-1"),
+					Image:        aws.String(testECSContainerRows[0].BaselineConfigurationName),
 					NetworkInterfaces: []*ecs.NetworkInterface{
 						{
 							PrivateIpv4Address: aws.String("172.16.4.5"),
@@ -130,15 +130,15 @@ var testECSDescribeTasksOutput = &ecs.DescribeTasksOutput{
 				},
 				{
 					ContainerArn: aws.String(testECSContainerRows[1].SerialAssetTagNumber),
-					Name: aws.String("test-container-2"),
-					Image: aws.String(testECSContainerRows[1].BaselineConfigurationName),
-					RuntimeId: aws.String("b026324c6904b2a9cb4b88d6d61c81d1-2468101214"),
+					Name:         aws.String("test-container-2"),
+					Image:        aws.String(testECSContainerRows[1].BaselineConfigurationName),
+					RuntimeId:    aws.String("b026324c6904b2a9cb4b88d6d61c81d1-2468101214"),
 				},
 			},
-			Group: aws.String("service:ecs-service-1"),
-			LaunchType: aws.String("FARGATE"),
+			Group:           aws.String("service:ecs-service-1"),
+			LaunchType:      aws.String("FARGATE"),
 			PlatformVersion: aws.String("1.4.0"),
-			TaskArn: aws.String("arn:aws:ecs:us-east-2:123456789101:task/ecs-cluster-1/b026324c6904b2a9cb4b88d6d61c81d1"),
+			TaskArn:         aws.String("arn:aws:ecs:us-east-2:123456789101:task/ecs-cluster-1/b026324c6904b2a9cb4b88d6d61c81d1"),
 		},
 		{
 			Attachments: []*ecs.Attachment{
@@ -146,15 +146,15 @@ var testECSDescribeTasksOutput = &ecs.DescribeTasksOutput{
 					Type: aws.String("ElasticNetworkInterface"),
 					Details: []*ecs.KeyValuePair{
 						{
-							Name: aws.String("networkInterfaceId"),
+							Name:  aws.String("networkInterfaceId"),
 							Value: aws.String("eni-abcdefgh"),
 						},
 						{
-							Name: aws.String("macAddress"),
+							Name:  aws.String("macAddress"),
 							Value: aws.String("ab:00:cd:11:ef:22"),
 						},
 						{
-							Name: aws.String("privateIPv4Address"),
+							Name:  aws.String("privateIPv4Address"),
 							Value: aws.String("10.9.8.7"),
 						},
 					},
@@ -163,8 +163,8 @@ var testECSDescribeTasksOutput = &ecs.DescribeTasksOutput{
 			Containers: []*ecs.Container{
 				{
 					ContainerArn: aws.String(testECSContainerRows[2].SerialAssetTagNumber),
-					Name: aws.String("test-container-3"),
-					Image: aws.String(testECSContainerRows[2].BaselineConfigurationName),
+					Name:         aws.String("test-container-3"),
+					Image:        aws.String(testECSContainerRows[2].BaselineConfigurationName),
 					NetworkInterfaces: []*ecs.NetworkInterface{
 						{
 							PrivateIpv4Address: aws.String("10.100.250.25"),
@@ -173,9 +173,9 @@ var testECSDescribeTasksOutput = &ecs.DescribeTasksOutput{
 					RuntimeId: aws.String("26ab0db90d72e28ad0ba1e22ee510510-1234567890"),
 				},
 			},
-			Group: aws.String("service:ecs-service-2"),
+			Group:      aws.String("service:ecs-service-2"),
 			LaunchType: aws.String("EC2"),
-			TaskArn: aws.String("arn:aws:ecs:us-east-2:123456789101:task/ecs-cluster-1/26ab0db90d72e28ad0ba1e22ee510510"),
+			TaskArn:    aws.String("arn:aws:ecs:us-east-2:123456789101:task/ecs-cluster-1/26ab0db90d72e28ad0ba1e22ee510510"),
 		},
 		{
 			Attachments: []*ecs.Attachment{
@@ -183,15 +183,15 @@ var testECSDescribeTasksOutput = &ecs.DescribeTasksOutput{
 					Type: aws.String("ElasticNetworkInterface"),
 					Details: []*ecs.KeyValuePair{
 						{
-							Name: aws.String("networkInterfaceId"),
+							Name:  aws.String("networkInterfaceId"),
 							Value: aws.String("eni-0a1b2c3d"),
 						},
 						{
-							Name: aws.String("macAddress"),
+							Name:  aws.String("macAddress"),
 							Value: aws.String("fe:99:dc:88:ba:77"),
 						},
 						{
-							Name: aws.String("privateIPv4Address"),
+							Name:  aws.String("privateIPv4Address"),
 							Value: aws.String("192.168.0.1"),
 						},
 					},
@@ -200,8 +200,8 @@ var testECSDescribeTasksOutput = &ecs.DescribeTasksOutput{
 			Containers: []*ecs.Container{
 				{
 					ContainerArn: aws.String(testECSContainerRows[3].SerialAssetTagNumber),
-					Name: aws.String("test-container-4"),
-					Image: aws.String(testECSContainerRows[3].BaselineConfigurationName),
+					Name:         aws.String("test-container-4"),
+					Image:        aws.String(testECSContainerRows[3].BaselineConfigurationName),
 					NetworkInterfaces: []*ecs.NetworkInterface{
 						{
 							PrivateIpv4Address: aws.String("10.200.10.1"),
@@ -210,10 +210,10 @@ var testECSDescribeTasksOutput = &ecs.DescribeTasksOutput{
 					RuntimeId: aws.String("6d7fce9fee471194aa8b5b6e47267f03-1234567890"),
 				},
 			},
-			Group: aws.String("service:ecs-service-3"),
-			LaunchType: aws.String("FARGATE"),
+			Group:           aws.String("service:ecs-service-3"),
+			LaunchType:      aws.String("FARGATE"),
 			PlatformVersion: aws.String("LATEST"),
-			TaskArn: aws.String("arn:aws:ecs:us-east-2:123456789101:task/ecs-cluster-1/6d7fce9fee471194aa8b5b6e47267f03"),
+			TaskArn:         aws.String("arn:aws:ecs:us-east-2:123456789101:task/ecs-cluster-1/6d7fce9fee471194aa8b5b6e47267f03"),
 		},
 	},
 }

--- a/internal/awsdata/elasticache.go
+++ b/internal/awsdata/elasticache.go
@@ -26,7 +26,9 @@ func (d *AWSData) loadElastiCacheNodes(region string) {
 		"region":  region,
 		"service": ServiceElastiCache,
 	})
+
 	log.Info("loading data")
+
 	var cacheClusters []*elasticache.CacheCluster
 	done := false
 	params := &elasticache.DescribeCacheClustersInput{
@@ -49,6 +51,7 @@ func (d *AWSData) loadElastiCacheNodes(region string) {
 	}
 
 	log.Info("processing data")
+
 	for _, c := range cacheClusters {
 		var vpcId string
 		groups, err := elasticacheSvc.DescribeCacheSubnetGroups(&elasticache.DescribeCacheSubnetGroupsInput{
@@ -76,8 +79,8 @@ func (d *AWSData) loadElastiCacheNodes(region string) {
 					SerialAssetTagNumber:           aws.StringValue(c.ARN),
 					VLANNetworkID:                  vpcId,
 				},
-		  }
-	  }
+			}
+		}
 	}
 
 	log.Info("finished processing data")

--- a/internal/awsdata/elasticache_test.go
+++ b/internal/awsdata/elasticache_test.go
@@ -102,7 +102,7 @@ var testElastiCacheNodeRows = []inventory.Row{
 }
 
 // Test Data
-var testElastiCacheNodeOutput = &elasticache.DescribeCacheClustersOutput{
+var testElastiCacheDescribeCacheClustersOutput = &elasticache.DescribeCacheClustersOutput{
 	CacheClusters: []*elasticache.CacheCluster{
 		{
 			ARN:                  aws.String(testElastiCacheNodeRows[0].SerialAssetTagNumber),
@@ -182,11 +182,11 @@ var testElastiCacheNodeOutput = &elasticache.DescribeCacheClustersOutput{
 	},
 }
 
-var testElastiCacheSubnetGroupOutput = &elasticache.DescribeCacheSubnetGroupsOutput{
+var testElastiCacheDescribeCacheSubnetGroupOutput = &elasticache.DescribeCacheSubnetGroupsOutput{
 	CacheSubnetGroups: []*elasticache.CacheSubnetGroup{
 		{
 			CacheSubnetGroupName: aws.String("cache-subnet-group"),
-			VpcId: aws.String(testElastiCacheNodeRows[0].VLANNetworkID),
+			VpcId:                aws.String(testElastiCacheNodeRows[0].VLANNetworkID),
 		},
 	},
 }
@@ -197,11 +197,11 @@ type ElastiCacheMock struct {
 }
 
 func (e ElastiCacheMock) DescribeCacheClusters(cfg *elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error) {
-	return testElastiCacheNodeOutput, nil
+	return testElastiCacheDescribeCacheClustersOutput, nil
 }
 
 func (e ElastiCacheMock) DescribeCacheSubnetGroups(cfg *elasticache.DescribeCacheSubnetGroupsInput) (*elasticache.DescribeCacheSubnetGroupsOutput, error) {
-	return testElastiCacheSubnetGroupOutput, nil
+	return testElastiCacheDescribeCacheSubnetGroupOutput, nil
 }
 
 type ElastiCacheErrorMock struct {

--- a/internal/awsdata/elb.go
+++ b/internal/awsdata/elb.go
@@ -1,7 +1,11 @@
 package awsdata
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/manywho/awsinventory/internal/inventory"
 	"github.com/sirupsen/logrus"
@@ -18,21 +22,55 @@ const (
 func (d *AWSData) loadELBs(region string) {
 	defer d.wg.Done()
 
+	ec2Svc := d.clients.GetEC2Client(region)
 	elbSvc := d.clients.GetELBClient(region)
 
 	log := d.log.WithFields(logrus.Fields{
 		"region":  region,
 		"service": ServiceELB,
 	})
+
 	log.Info("loading data")
-	out, err := elbSvc.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{})
+
+	var partition string
+	if p, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok {
+		partition = p.ID()
+	}
+
+	var accountId string
+	out, err := ec2Svc.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		MaxResults: aws.Int64(5),
+	})
 	if err != nil {
 		d.results <- result{Err: err}
 		return
+	} else if len(out.SecurityGroups) > 0 {
+		accountId = aws.StringValue(out.SecurityGroups[0].OwnerId)
+	}
+
+	var loadBalancers []*elb.LoadBalancerDescription
+	done := false
+	params := &elb.DescribeLoadBalancersInput{}
+	for !done {
+		out, err := elbSvc.DescribeLoadBalancers(params)
+
+		if err != nil {
+			d.results <- result{Err: err}
+			return
+		}
+
+		loadBalancers = append(loadBalancers, out.LoadBalancerDescriptions...)
+
+		if out.NextMarker == nil {
+			done = true
+		} else {
+			params.Marker = out.NextMarker
+		}
 	}
 
 	log.Info("processing data")
-	for _, l := range out.LoadBalancerDescriptions {
+
+	for _, l := range loadBalancers {
 		var public bool
 		if aws.StringValue(l.Scheme) == "internet-facing" {
 			public = true
@@ -49,6 +87,7 @@ func (d *AWSData) loadELBs(region string) {
 				Location:              region,
 				AssetType:             AssetTypeELB,
 				Function:              aws.StringValue(l.CanonicalHostedZoneName),
+				SerialAssetTagNumber:  fmt.Sprintf("arn:%s:elasticloadbalancing:%s:%s:loadbalancer/%s", partition, region, accountId, aws.StringValue(l.LoadBalancerName)),
 				VLANNetworkID:         aws.StringValue(l.VPCId),
 			},
 		}

--- a/internal/awsdata/elb_test.go
+++ b/internal/awsdata/elb_test.go
@@ -23,6 +23,7 @@ var testELBRows = []inventory.Row{
 		Location:              DefaultRegion,
 		AssetType:             AssetTypeELB,
 		Function:              "mydomain.com",
+		SerialAssetTagNumber:  "arn:aws:elasticloadbalancing:us-east-1:012345678910:loadbalancer/abcdefgh12345678",
 		VLANNetworkID:         "vpc-abcdefgh",
 	},
 	{
@@ -33,6 +34,7 @@ var testELBRows = []inventory.Row{
 		Location:              DefaultRegion,
 		AssetType:             AssetTypeELB,
 		Function:              "another.com",
+		SerialAssetTagNumber:  "arn:aws:elasticloadbalancing:us-east-1:012345678910:loadbalancer/12345678abcdefgh",
 		VLANNetworkID:         "vpc-12345678",
 	},
 	{
@@ -43,12 +45,13 @@ var testELBRows = []inventory.Row{
 		Location:              DefaultRegion,
 		AssetType:             AssetTypeELB,
 		Function:              "yetanother.com",
+		SerialAssetTagNumber:  "arn:aws:elasticloadbalancing:us-east-1:012345678910:loadbalancer/a1b2c3d4e5f6g7h8",
 		VLANNetworkID:         "vpc-a1b2c3d4",
 	},
 }
 
 // Test Data
-var testELBOutput = &elb.DescribeLoadBalancersOutput{
+var testELBDescribeLoadBalancersOutput = &elb.DescribeLoadBalancersOutput{
 	LoadBalancerDescriptions: []*elb.LoadBalancerDescription{
 		{
 			LoadBalancerName:        aws.String(testELBRows[0].UniqueAssetIdentifier),
@@ -80,7 +83,7 @@ type ELBMock struct {
 }
 
 func (e ELBMock) DescribeLoadBalancers(cfg *elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error) {
-	return testELBOutput, nil
+	return testELBDescribeLoadBalancersOutput, nil
 }
 
 type ELBErrorMock struct {
@@ -93,7 +96,7 @@ func (e ELBErrorMock) DescribeLoadBalancers(cfg *elb.DescribeLoadBalancersInput)
 
 // Tests
 func TestCanLoadELBs(t *testing.T) {
-	d := New(logrus.New(), TestClients{ELB: ELBMock{}})
+	d := New(logrus.New(), TestClients{EC2: EC2Mock{}, ELB: ELBMock{}})
 
 	d.Load([]string{DefaultRegion}, []string{ServiceELB})
 
@@ -109,7 +112,7 @@ func TestCanLoadELBs(t *testing.T) {
 func TestLoadELBsLogsError(t *testing.T) {
 	logger, hook := logrustest.NewNullLogger()
 
-	d := New(logger, TestClients{ELB: ELBErrorMock{}})
+	d := New(logger, TestClients{EC2: EC2ErrorMock{}, ELB: ELBErrorMock{}})
 
 	d.Load([]string{DefaultRegion}, []string{ServiceELB})
 

--- a/internal/awsdata/elbv2_test.go
+++ b/internal/awsdata/elbv2_test.go
@@ -22,6 +22,7 @@ var testELBV2Rows = []inventory.Row{
 		DNSNameOrURL:          "abcdefgh12345678.us-east-1.elb.amazonaws.com",
 		Location:              DefaultRegion,
 		AssetType:             AssetTypeALB,
+		SerialAssetTagNumber:  "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/abcdefgh12345678/50dc6c495c0c9188",
 		VLANNetworkID:         "vpc-abcdefgh",
 	},
 	{
@@ -31,6 +32,7 @@ var testELBV2Rows = []inventory.Row{
 		DNSNameOrURL:          "12345678abcdefgh.us-east-1.elb.amazonaws.com",
 		Location:              DefaultRegion,
 		AssetType:             AssetTypeNLB,
+		SerialAssetTagNumber:  "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/net/12345678abcdefgh/b6dabd72b1aef5a2",
 		VLANNetworkID:         "vpc-12345678",
 	},
 	{
@@ -40,33 +42,37 @@ var testELBV2Rows = []inventory.Row{
 		DNSNameOrURL:          "a1b2c3d4e5f6g7h8.us-east-1.elb.amazonaws.com",
 		Location:              DefaultRegion,
 		AssetType:             AssetTypeALB,
+		SerialAssetTagNumber:  "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/a1b2c3d4e5f6g7h8/573c812d8a4526b7",
 		VLANNetworkID:         "vpc-a1b2c3d4",
 	},
 }
 
 // Test Data
-var testELBV2Output = &elbv2.DescribeLoadBalancersOutput{
+var testELBV2DescribeLoadBalancersOutput = &elbv2.DescribeLoadBalancersOutput{
 	LoadBalancers: []*elbv2.LoadBalancer{
 		{
-			LoadBalancerName:        aws.String(testELBV2Rows[0].UniqueAssetIdentifier),
-			DNSName:                 aws.String(testELBV2Rows[0].DNSNameOrURL),
-			Type:                    aws.String("application"),
-			Scheme:                  aws.String("internet-facing"),
-			VpcId:                   aws.String(testELBV2Rows[0].VLANNetworkID),
+			LoadBalancerName: aws.String(testELBV2Rows[0].UniqueAssetIdentifier),
+			LoadBalancerArn:  aws.String(testELBV2Rows[0].SerialAssetTagNumber),
+			DNSName:          aws.String(testELBV2Rows[0].DNSNameOrURL),
+			Type:             aws.String("application"),
+			Scheme:           aws.String("internet-facing"),
+			VpcId:            aws.String(testELBV2Rows[0].VLANNetworkID),
 		},
 		{
-			LoadBalancerName:        aws.String(testELBV2Rows[1].UniqueAssetIdentifier),
-			DNSName:                 aws.String(testELBV2Rows[1].DNSNameOrURL),
-			Type:                    aws.String("network"),
-			Scheme:                  aws.String("internet-facing"),
-			VpcId:                   aws.String(testELBV2Rows[1].VLANNetworkID),
+			LoadBalancerName: aws.String(testELBV2Rows[1].UniqueAssetIdentifier),
+			LoadBalancerArn:  aws.String(testELBV2Rows[1].SerialAssetTagNumber),
+			DNSName:          aws.String(testELBV2Rows[1].DNSNameOrURL),
+			Type:             aws.String("network"),
+			Scheme:           aws.String("internet-facing"),
+			VpcId:            aws.String(testELBV2Rows[1].VLANNetworkID),
 		},
 		{
-			LoadBalancerName:        aws.String(testELBV2Rows[2].UniqueAssetIdentifier),
-			DNSName:                 aws.String(testELBV2Rows[2].DNSNameOrURL),
-			Type:                    aws.String("application"),
-			Scheme:                  aws.String("internal"),
-			VpcId:                   aws.String(testELBV2Rows[2].VLANNetworkID),
+			LoadBalancerName: aws.String(testELBV2Rows[2].UniqueAssetIdentifier),
+			LoadBalancerArn:  aws.String(testELBV2Rows[2].SerialAssetTagNumber),
+			DNSName:          aws.String(testELBV2Rows[2].DNSNameOrURL),
+			Type:             aws.String("application"),
+			Scheme:           aws.String("internal"),
+			VpcId:            aws.String(testELBV2Rows[2].VLANNetworkID),
 		},
 	},
 }
@@ -77,7 +83,7 @@ type ELBV2Mock struct {
 }
 
 func (e ELBV2Mock) DescribeLoadBalancers(cfg *elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error) {
-	return testELBV2Output, nil
+	return testELBV2DescribeLoadBalancersOutput, nil
 }
 
 type ELBV2ErrorMock struct {

--- a/internal/awsdata/es.go
+++ b/internal/awsdata/es.go
@@ -26,7 +26,9 @@ func (d *AWSData) loadElasticsearchDomains(region string) {
 		"region":  region,
 		"service": ServiceElasticsearchService,
 	})
+
 	log.Info("loading data")
+
 	out, err := elasticsearchserviceSvc.ListDomainNames(&elasticsearchservice.ListDomainNamesInput{})
 	if err != nil {
 		d.results <- result{Err: err}
@@ -39,6 +41,7 @@ func (d *AWSData) loadElasticsearchDomains(region string) {
 	}
 
 	log.Info("processing data")
+
 	// API call only accepts 5 domains at a time
 	for i := 0; i+1 < len(domains); i += 5 {
 		var j int = i + 5

--- a/internal/awsdata/es_test.go
+++ b/internal/awsdata/es_test.go
@@ -57,21 +57,21 @@ var testElasticsearchDomainRows = []inventory.Row{
 }
 
 // Test Data
-var testDomainNamesOutput = &elasticsearchservice.ListDomainNamesOutput{
+var testElasticsearchListDomainNamesOutput = &elasticsearchservice.ListDomainNamesOutput{
 	DomainNames: []*elasticsearchservice.DomainInfo{
 		{
-		  DomainName: aws.String(testElasticsearchDomainRows[0].UniqueAssetIdentifier),
+			DomainName: aws.String(testElasticsearchDomainRows[0].UniqueAssetIdentifier),
 		},
 		{
-		  DomainName: aws.String(testElasticsearchDomainRows[1].UniqueAssetIdentifier),
+			DomainName: aws.String(testElasticsearchDomainRows[1].UniqueAssetIdentifier),
 		},
 		{
-		  DomainName: aws.String(testElasticsearchDomainRows[2].UniqueAssetIdentifier),
+			DomainName: aws.String(testElasticsearchDomainRows[2].UniqueAssetIdentifier),
 		},
 	},
 }
 
-var testElasticsearchDomainsOutput = &elasticsearchservice.DescribeElasticsearchDomainsOutput{
+var testElasticsearchDescribeElasticsearchDomainsOutput = &elasticsearchservice.DescribeElasticsearchDomainsOutput{
 	DomainStatusList: []*elasticsearchservice.ElasticsearchDomainStatus{
 		{
 			DomainName: aws.String(testElasticsearchDomainRows[0].UniqueAssetIdentifier),
@@ -124,11 +124,11 @@ type ElasticsearchServiceMock struct {
 }
 
 func (e ElasticsearchServiceMock) ListDomainNames(cfg *elasticsearchservice.ListDomainNamesInput) (*elasticsearchservice.ListDomainNamesOutput, error) {
-	return testDomainNamesOutput, nil
+	return testElasticsearchListDomainNamesOutput, nil
 }
 
 func (e ElasticsearchServiceMock) DescribeElasticsearchDomains(cfg *elasticsearchservice.DescribeElasticsearchDomainsInput) (*elasticsearchservice.DescribeElasticsearchDomainsOutput, error) {
-	return testElasticsearchDomainsOutput, nil
+	return testElasticsearchDescribeElasticsearchDomainsOutput, nil
 }
 
 type ElasticsearchServiceErrorMock struct {

--- a/internal/awsdata/iam_test.go
+++ b/internal/awsdata/iam_test.go
@@ -19,30 +19,36 @@ var testIAMRows = []inventory.Row{
 		UniqueAssetIdentifier: "test-user-1",
 		Virtual:               true,
 		AssetType:             AssetTypeIAMUser,
+		SerialAssetTagNumber:  "arn:aws:iam::123456789012:user/test-user-1",
 	},
 	{
 		UniqueAssetIdentifier: "test-user-2",
 		Virtual:               true,
 		AssetType:             AssetTypeIAMUser,
+		SerialAssetTagNumber:  "arn:aws:iam::123456789012:user/test-user-2",
 	},
 	{
 		UniqueAssetIdentifier: "test-user-3",
 		Virtual:               true,
 		AssetType:             AssetTypeIAMUser,
+		SerialAssetTagNumber:  "arn:aws:iam::123456789012:user/test-user-3",
 	},
 }
 
 // Test Data
-var testIAMOutput = &iam.ListUsersOutput{
+var testIAMListUsersOutput = &iam.ListUsersOutput{
 	Users: []*iam.User{
 		{
 			UserName: aws.String(testIAMRows[0].UniqueAssetIdentifier),
+			Arn:      aws.String(testIAMRows[0].SerialAssetTagNumber),
 		},
 		{
 			UserName: aws.String(testIAMRows[1].UniqueAssetIdentifier),
+			Arn:      aws.String(testIAMRows[1].SerialAssetTagNumber),
 		},
 		{
 			UserName: aws.String(testIAMRows[2].UniqueAssetIdentifier),
+			Arn:      aws.String(testIAMRows[2].SerialAssetTagNumber),
 		},
 	},
 }
@@ -53,7 +59,7 @@ type IAMMock struct {
 }
 
 func (e IAMMock) ListUsers(cfg *iam.ListUsersInput) (*iam.ListUsersOutput, error) {
-	return testIAMOutput, nil
+	return testIAMListUsersOutput, nil
 }
 
 type IAMErrorMock struct {

--- a/internal/awsdata/rds_test.go
+++ b/internal/awsdata/rds_test.go
@@ -18,21 +18,27 @@ var testRDSInstanceRows = []inventory.Row{
 	{
 		UniqueAssetIdentifier:          "test-db-1",
 		Virtual:                        true,
+		Public:                         false,
 		DNSNameOrURL:                   "test-db-1.rds.aws.amazon.com",
 		Location:                       DefaultRegion,
 		AssetType:                      "RDS Instance",
 		HardwareMakeModel:              "db.t2.medium",
+		SoftwareDatabaseVendor:         "mysql",
 		SoftwareDatabaseNameAndVersion: "mysql 5.7",
+		SerialAssetTagNumber:           "arn:aws:rds:us-east-1:123456789012:db:test-db-1",
 		VLANNetworkID:                  "vpc-12345678",
 	},
 	{
 		UniqueAssetIdentifier:          "test-db-2",
 		Virtual:                        true,
+		Public:                         false,
 		DNSNameOrURL:                   "test-db-2.rds.aws.amazon.com",
 		Location:                       DefaultRegion,
 		AssetType:                      "RDS Instance",
 		HardwareMakeModel:              "db.t2.small",
+		SoftwareDatabaseVendor:         "postgres",
 		SoftwareDatabaseNameAndVersion: "postgres 9.6",
+		SerialAssetTagNumber:           "arn:aws:rds:us-east-1:123456789012:db:test-db-2",
 		VLANNetworkID:                  "vpc-abcdefgh",
 	},
 	{
@@ -43,16 +49,19 @@ var testRDSInstanceRows = []inventory.Row{
 		Location:                       DefaultRegion,
 		AssetType:                      "RDS Instance",
 		HardwareMakeModel:              "db.m4.large",
+		SoftwareDatabaseVendor:         "postgres",
 		SoftwareDatabaseNameAndVersion: "postgres 10.0",
+		SerialAssetTagNumber:           "arn:aws:rds:us-east-1:123456789012:db:test-db-3",
 		VLANNetworkID:                  "vpc-a1b2c3d4",
 	},
 }
 
 // Test Data
-var testRDSInstanceOutput = &rds.DescribeDBInstancesOutput{
+var testRDSDescribeDBInstancesOutput = &rds.DescribeDBInstancesOutput{
 	DBInstances: []*rds.DBInstance{
 		{
 			DBInstanceIdentifier: aws.String(testRDSInstanceRows[0].UniqueAssetIdentifier),
+			DBInstanceArn:        aws.String(testRDSInstanceRows[0].SerialAssetTagNumber),
 			Engine:               aws.String("mysql"),
 			EngineVersion:        aws.String("5.7"),
 			DBInstanceClass:      aws.String("db.t2.medium"),
@@ -66,6 +75,7 @@ var testRDSInstanceOutput = &rds.DescribeDBInstancesOutput{
 		},
 		{
 			DBInstanceIdentifier: aws.String(testRDSInstanceRows[1].UniqueAssetIdentifier),
+			DBInstanceArn:        aws.String(testRDSInstanceRows[1].SerialAssetTagNumber),
 			Engine:               aws.String("postgres"),
 			EngineVersion:        aws.String("9.6"),
 			DBInstanceClass:      aws.String("db.t2.small"),
@@ -79,6 +89,7 @@ var testRDSInstanceOutput = &rds.DescribeDBInstancesOutput{
 		},
 		{
 			DBInstanceIdentifier: aws.String(testRDSInstanceRows[2].UniqueAssetIdentifier),
+			DBInstanceArn:        aws.String(testRDSInstanceRows[2].SerialAssetTagNumber),
 			Engine:               aws.String("postgres"),
 			EngineVersion:        aws.String("10.0"),
 			DBInstanceClass:      aws.String("db.m4.large"),
@@ -99,7 +110,7 @@ type RDSMock struct {
 }
 
 func (e RDSMock) DescribeDBInstances(cfg *rds.DescribeDBInstancesInput) (*rds.DescribeDBInstancesOutput, error) {
-	return testRDSInstanceOutput, nil
+	return testRDSDescribeDBInstancesOutput, nil
 }
 
 type RDSErrorMock struct {

--- a/internal/awsdata/s3_test.go
+++ b/internal/awsdata/s3_test.go
@@ -17,20 +17,29 @@ import (
 var testS3Rows = []inventory.Row{
 	{
 		UniqueAssetIdentifier: "test-bucket-1",
+		Virtual:               true,
+		Location:              DefaultRegion,
 		AssetType:             AssetTypeS3Bucket,
+		SerialAssetTagNumber:  "arn:aws:s3:::test-bucket-1",
 	},
 	{
 		UniqueAssetIdentifier: "test-bucket-2",
+		Virtual:               true,
+		Location:              DefaultRegion,
 		AssetType:             AssetTypeS3Bucket,
+		SerialAssetTagNumber:  "arn:aws:s3:::test-bucket-2",
 	},
 	{
 		UniqueAssetIdentifier: "test-bucket-3",
+		Virtual:               true,
+		Location:              DefaultRegion,
 		AssetType:             AssetTypeS3Bucket,
+		SerialAssetTagNumber:  "arn:aws:s3:::test-bucket-3",
 	},
 }
 
 // Test Data
-var testS3Output = &s3.ListBucketsOutput{
+var testS3ListBucketsOutput = &s3.ListBucketsOutput{
 	Buckets: []*s3.Bucket{
 		{
 			Name: aws.String(testS3Rows[0].UniqueAssetIdentifier),
@@ -44,13 +53,21 @@ var testS3Output = &s3.ListBucketsOutput{
 	},
 }
 
+var testS3GetBucketLocationOutput = &s3.GetBucketLocationOutput{
+	LocationConstraint: nil,
+}
+
 // Mocks
 type S3Mock struct {
 	s3iface.S3API
 }
 
 func (e S3Mock) ListBuckets(cfg *s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
-	return testS3Output, nil
+	return testS3ListBucketsOutput, nil
+}
+
+func (e S3Mock) GetBucketLocation(cfg *s3.GetBucketLocationInput) (*s3.GetBucketLocationOutput, error) {
+	return testS3GetBucketLocationOutput, nil
 }
 
 type S3ErrorMock struct {
@@ -61,11 +78,15 @@ func (e S3ErrorMock) ListBuckets(cfg *s3.ListBucketsInput) (*s3.ListBucketsOutpu
 	return &s3.ListBucketsOutput{}, testError
 }
 
+func (e S3ErrorMock) GetBucketLocation(cfg *s3.GetBucketLocationInput) (*s3.GetBucketLocationOutput, error) {
+	return &s3.GetBucketLocationOutput{}, testError
+}
+
 // Tests
 func TestCanLoadS3Buckets(t *testing.T) {
 	d := New(logrus.New(), TestClients{S3: S3Mock{}})
 
-	d.Load([]string{}, []string{ServiceS3})
+	d.Load([]string{DefaultRegion}, []string{ServiceS3})
 
 	var count int
 	d.MapRows(func(row inventory.Row) error {


### PR DESCRIPTION
* Use pagination for all API calls where supported.
* Move S3 to be a "regional" service, as while S3 bucket names are global, the actual buckets and the objects in them are stored on a per-region basis.
* Change hasRegionalServices() to use a list of globalServices (there's only one) versus a long list of regional services.
* Add ARN to all resources (which sometimes requires manually constructing it using separate calls to get the partition and account ID).
* Add missing columns and standardize existing ones for several resources.