### PR TITLE
Add support for ECR images

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage of ./awsinventory:
   -o, --output-file string   path to the output file (default "inventory.csv")
       --print-regions        prints the available AWS regions
   -r, --regions strings      regions to gather data from
-  -s, --services strings     services to gather data from (default [cloudfront,codecommit,dynamodb,ebs,ec2,ecs,elasticache,elb,elbv2,es,iam,kms,lambda,rds,s3,sqs])
+  -s, --services strings     services to gather data from (default [cloudfront,codecommit,dynamodb,ebs,ec2,ecr,ecs,elasticache,elb,elbv2,es,iam,kms,lambda,rds,s3,sqs])
   -v, --version              prints the version information
 ```
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/aws/aws-sdk-go v1.35.8 h1:+S3BTWePYImKLh7DUJxMVm+/FQUnmHADsMzo/psHFr4=
 github.com/aws/aws-sdk-go v1.35.8/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
+github.com/aws/aws-sdk-go v1.35.11 h1:LICFl2K+3Y5dMTW6PCV6ycK8fzIxs21HvDhI5A3Ee3Y=
 github.com/aws/aws-sdk-go v1.35.11/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/awsdata/clients.go
+++ b/internal/awsdata/clients.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -43,6 +45,7 @@ type Clients interface {
 	GetCodeCommitClient(region string) codecommitiface.CodeCommitAPI
 	GetDynamoDBClient(region string) dynamodbiface.DynamoDBAPI
 	GetEC2Client(region string) ec2iface.EC2API
+	GetECRClient(region string) ecriface.ECRAPI
 	GetECSClient(region string) ecsiface.ECSAPI
 	GetElastiCacheClient(region string) elasticacheiface.ElastiCacheAPI
 	GetElasticsearchServiceClient(region string) elasticsearchserviceiface.ElasticsearchServiceAPI
@@ -78,6 +81,11 @@ func (c DefaultClients) GetDynamoDBClient(region string) dynamodbiface.DynamoDBA
 // GetEC2Client returns a new EC2 client for the given region
 func (c DefaultClients) GetEC2Client(region string) ec2iface.EC2API {
 	return ec2.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+}
+
+// GetECRClient returns a new ECS client for the given region
+func (c DefaultClients) GetECRClient(region string) ecriface.ECRAPI {
+	return ecr.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
 }
 
 // GetECSClient returns a new ECS client for the given region

--- a/internal/awsdata/clients_test.go
+++ b/internal/awsdata/clients_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/codecommit/codecommitiface"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 	"github.com/aws/aws-sdk-go/service/elasticache/elasticacheiface"
 	"github.com/aws/aws-sdk-go/service/elasticsearchservice/elasticsearchserviceiface"
@@ -28,6 +29,7 @@ type TestClients struct {
 	CodeCommit           codecommitiface.CodeCommitAPI
 	DynamoDB             dynamodbiface.DynamoDBAPI
 	EC2                  ec2iface.EC2API
+	ECR                  ecriface.ECRAPI
 	ECS                  ecsiface.ECSAPI
 	ElastiCache          elasticacheiface.ElastiCacheAPI
 	ElasticsearchService elasticsearchserviceiface.ElasticsearchServiceAPI
@@ -56,6 +58,10 @@ func (c TestClients) GetDynamoDBClient(region string) dynamodbiface.DynamoDBAPI 
 
 func (c TestClients) GetEC2Client(region string) ec2iface.EC2API {
 	return c.EC2
+}
+
+func (c TestClients) GetECRClient(region string) ecriface.ECRAPI {
+	return c.ECR
 }
 
 func (c TestClients) GetECSClient(region string) ecsiface.ECSAPI {

--- a/internal/awsdata/data.go
+++ b/internal/awsdata/data.go
@@ -62,6 +62,7 @@ func New(logger *logrus.Logger, clients Clients) *AWSData {
 		ServiceDynamoDB,
 		ServiceEBS,
 		ServiceEC2,
+		ServiceECR,
 		ServiceECS,
 		ServiceElastiCache,
 		ServiceElasticsearchService,
@@ -152,6 +153,12 @@ func (d *AWSData) Load(regions, services []string) {
 			d.log.Debug("including EC2 service")
 			d.wg.Add(1)
 			go d.loadEC2Instances(region)
+		}
+
+		if stringInSlice(ServiceECR, services) {
+			d.log.Debug("including ECR service")
+			d.wg.Add(1)
+			go d.loadECRImages(region)
 		}
 
 		if stringInSlice(ServiceECS, services) {

--- a/internal/awsdata/ecr.go
+++ b/internal/awsdata/ecr.go
@@ -1,0 +1,96 @@
+package awsdata
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/manywho/awsinventory/internal/inventory"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// AssetTypeECRImage is the value used in the AssetType field when fetching ECR images
+	AssetTypeECRImage string = "ECR Image"
+
+	// ServiceECR is the key for the ECR service
+	ServiceECR string = "ecr"
+)
+
+func (d *AWSData) loadECRImages(region string) {
+	defer d.wg.Done()
+
+	ecrSvc := d.clients.GetECRClient(region)
+
+	log := d.log.WithFields(logrus.Fields{
+		"region":  region,
+		"service": ServiceECR,
+	})
+
+	log.Info("loading data")
+
+	var repositories []*ecr.Repository
+	done := false
+	params := &ecr.DescribeRepositoriesInput{}
+	for !done {
+		out, err := ecrSvc.DescribeRepositories(params)
+
+		if err != nil {
+			d.results <- result{Err: err}
+			return
+		}
+
+		repositories = append(repositories, out.Repositories...)
+
+		if out.NextToken == nil {
+			done = true
+		} else {
+			params.NextToken = out.NextToken
+		}
+	}
+
+	log.Info("processing data")
+
+	for _, r := range repositories {
+		var images []*ecr.ImageDetail
+		done := false
+		params := &ecr.DescribeImagesInput{
+			RepositoryName: r.RepositoryName,
+		}
+		for !done {
+			out, err := ecrSvc.DescribeImages(params)
+
+			if err != nil {
+				d.results <- result{Err: err}
+				return
+			}
+
+			images = append(images, out.ImageDetails...)
+
+			if out.NextToken == nil {
+				done = true
+			} else {
+				params.NextToken = out.NextToken
+			}
+		}
+
+		for _, i := range images {
+			d.results <- result{
+				Row: inventory.Row{
+					UniqueAssetIdentifier: fmt.Sprintf("%s-%s", aws.StringValue(i.RepositoryName), aws.StringValue(i.ImageDigest)),
+					Virtual:               true,
+					Public:                false,
+					DNSNameOrURL:          aws.StringValue(r.RepositoryUri),
+					Location:              region,
+					AssetType:             AssetTypeECRImage,
+					Function:              strings.Join(aws.StringValueSlice(i.ImageTags), ","),
+					Comments:              humanReadableBytes(aws.Int64Value(i.ImageSizeInBytes)),
+					SerialAssetTagNumber:  aws.StringValue(i.ImageDigest),
+				},
+			}
+		}
+	}
+
+	log.Info("finished processing data")
+}

--- a/internal/awsdata/ecr_test.go
+++ b/internal/awsdata/ecr_test.go
@@ -1,0 +1,153 @@
+package awsdata_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/manywho/awsinventory/internal/awsdata"
+	"github.com/manywho/awsinventory/internal/inventory"
+)
+
+var testECRImageRows = []inventory.Row{
+	{
+		UniqueAssetIdentifier: "TestRepo1-sha256:7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add73ff431ed",
+		Virtual:               true,
+		Public:                false,
+		DNSNameOrURL:          "012345678910.dkr.ecr.us-east-1.amazonaws.com/TestRepo1",
+		Location:              DefaultRegion,
+		AssetType:             AssetTypeECRImage,
+		Function:              "latest",
+		Comments:              "200.6 MB",
+		SerialAssetTagNumber:  "sha256:7692c3ad3540bb803c020b3aee66cd8887123234ea0c6e7143c0add73ff431ed",
+	},
+	{
+		UniqueAssetIdentifier: "TestRepo1-sha256:3fc4ccfe745870e2c0d99f71f30ff0656c8dedd41cc1d7d3d376b0dbe685e2f3",
+		Virtual:               true,
+		Public:                false,
+		DNSNameOrURL:          "012345678910.dkr.ecr.us-east-1.amazonaws.com/TestRepo1",
+		Location:              DefaultRegion,
+		AssetType:             AssetTypeECRImage,
+		Function:              "previous,last",
+		Comments:              "800.3 MB",
+		SerialAssetTagNumber:  "sha256:3fc4ccfe745870e2c0d99f71f30ff0656c8dedd41cc1d7d3d376b0dbe685e2f3",
+	},
+	{
+		UniqueAssetIdentifier: "TestRepo1-sha256:8b5b9db0c13db24256c829aa364aa90c6d2eba318b9232a4ab9313b954d3555f",
+		Virtual:               true,
+		Public:                false,
+		DNSNameOrURL:          "012345678910.dkr.ecr.us-east-1.amazonaws.com/TestRepo1",
+		Location:              DefaultRegion,
+		AssetType:             AssetTypeECRImage,
+		Comments:              "1.1 GB",
+		SerialAssetTagNumber:  "sha256:8b5b9db0c13db24256c829aa364aa90c6d2eba318b9232a4ab9313b954d3555f",
+	},
+}
+
+// Test Data
+var testECRDescribeRepositoriesOutput = &ecr.DescribeRepositoriesOutput{
+	NextToken: aws.String("arn:aws:ecr:region:012345678910:repository/TestRepo1"),
+	Repositories: []*ecr.Repository{
+		{
+			RepositoryArn:  aws.String("arn:aws:ecr:region:012345678910:repository/TestRepo1"),
+			RepositoryName: aws.String("TestRepo1"),
+			RepositoryUri:  aws.String(testECRImageRows[0].DNSNameOrURL),
+		},
+	},
+}
+
+var testECRDescribeImagesOutputPage1 = &ecr.DescribeImagesOutput{
+	ImageDetails: []*ecr.ImageDetail{
+		{
+			ImageDigest:      aws.String(testECRImageRows[0].SerialAssetTagNumber),
+			ImageSizeInBytes: aws.Int64(210344346),
+			ImageTags: []*string{
+				aws.String("latest"),
+			},
+			RepositoryName: aws.String("TestRepo1"),
+		},
+		{
+			ImageDigest:      aws.String(testECRImageRows[1].SerialAssetTagNumber),
+			ImageSizeInBytes: aws.Int64(839175373),
+			ImageTags: []*string{
+				aws.String("previous"),
+				aws.String("last"),
+			},
+			RepositoryName: aws.String("TestRepo1"),
+		},
+	},
+	NextToken: aws.String(testECRImageRows[1].SerialAssetTagNumber),
+}
+
+var testECRDescribeImagesOutputPage2 = &ecr.DescribeImagesOutput{
+	ImageDetails: []*ecr.ImageDetail{
+		{
+			ImageDigest:      aws.String(testECRImageRows[2].SerialAssetTagNumber),
+			ImageSizeInBytes: aws.Int64(1181115402),
+			RepositoryName:   aws.String("TestRepo1"),
+		},
+	},
+}
+
+// Mocks
+type ECRMock struct {
+	ecriface.ECRAPI
+}
+
+func (e ECRMock) DescribeRepositories(cfg *ecr.DescribeRepositoriesInput) (*ecr.DescribeRepositoriesOutput, error) {
+	if cfg.NextToken == testECRDescribeRepositoriesOutput.NextToken {
+		return &ecr.DescribeRepositoriesOutput{}, nil
+	}
+
+	return testECRDescribeRepositoriesOutput, nil
+}
+
+func (e ECRMock) DescribeImages(cfg *ecr.DescribeImagesInput) (*ecr.DescribeImagesOutput, error) {
+	if cfg.NextToken == nil {
+		return testECRDescribeImagesOutputPage1, nil
+	}
+
+	return testECRDescribeImagesOutputPage2, nil
+}
+
+type ECRErrorMock struct {
+	ecriface.ECRAPI
+}
+
+func (e ECRErrorMock) DescribeRepositories(cfg *ecr.DescribeRepositoriesInput) (*ecr.DescribeRepositoriesOutput, error) {
+	return &ecr.DescribeRepositoriesOutput{}, testError
+}
+
+func (e ECRErrorMock) DescribeImages(cfg *ecr.DescribeImagesInput) (*ecr.DescribeImagesOutput, error) {
+	return &ecr.DescribeImagesOutput{}, testError
+}
+
+// Tests
+func TestCanLoadECRImages(t *testing.T) {
+	d := New(logrus.New(), TestClients{ECR: ECRMock{}})
+
+	d.Load([]string{DefaultRegion}, []string{ServiceECR})
+
+	var count int
+	d.MapRows(func(row inventory.Row) error {
+		require.Equal(t, testECRImageRows[count], row)
+		count++
+		return nil
+	})
+	require.Equal(t, 3, count)
+}
+
+func TestLoadECRImagesLogsError(t *testing.T) {
+	logger, hook := logrustest.NewNullLogger()
+
+	d := New(logger, TestClients{ECR: ECRErrorMock{}})
+
+	d.Load([]string{DefaultRegion}, []string{ServiceECR})
+
+	require.Contains(t, hook.LastEntry().Message, testError.Error())
+}


### PR DESCRIPTION
Proposed changes by the FedRAMP PMO in https://www.fedramp.gov/vulnerability-scanning-requirements-for-the-deployment-and-use-of-containers/ include:

> **Asset Management and Inventory Reporting for Deployed Containers**: A unique asset identifier
> must be assigned to every image which corresponds to one or more production-deployed
> containers. These image-based asset identifiers must be documented in the FedRAMP Integrated
> Inventory Workbook Template. Instances of production-deployed containers must be tracked
> internally by the CSP via an automated mechanism, which must be validated by a 3PAO to meet the
> baseline control CM-8. Every production-deployed container must correspond to the image from
> which the deployed container originated, in order to identify the total number of relevant
> vulnerabilities on production associated with that container. While individually deployed instances of
> containers should be tracked internally by the CSP, they do not need to be included as part of the
> FedRAMP Integrated Inventory Workbook Template, unless they are specifically the target of a scan
> performed by a security sensor. If they are the target of a scan performed by a security sensor, they
> must be included as part of the FedRAMP Integrated Inventory Workbook Template ConMon
> deliverable, in accordance with the Guide for Determining Eligibility and Requirements for the Use of
> Sampling for Vulnerability Scans document if applicable.