### PR TITLE
S3 performance improvement

### DIFF
--- a/internal/awsdata/data.go
+++ b/internal/awsdata/data.go
@@ -76,7 +76,7 @@ func New(logger *logrus.Logger, clients Clients) *AWSData {
 		clients:       clients,
 		validRegions:  regions,
 		validServices: services,
-		rows:          make(chan inventory.Row, 100),
+		rows:          make(chan inventory.Row, 200),
 		log:           logger,
 		wg:            sync.WaitGroup{},
 	}

--- a/internal/awsdata/data.go
+++ b/internal/awsdata/data.go
@@ -76,7 +76,7 @@ func New(logger *logrus.Logger, clients Clients) *AWSData {
 		clients:       clients,
 		validRegions:  regions,
 		validServices: services,
-		rows:          make(chan inventory.Row, 200),
+		rows:          make(chan inventory.Row, 100),
 		log:           logger,
 		wg:            sync.WaitGroup{},
 	}


### PR DESCRIPTION
This processes s3 buckets in parallel as sequentially getting the bucket location is very slow.

Testing in an account with 73 buckets shows roughly a 10x speed increase.

**Before:**
```
$ time ./awsinventory -r us-east-1 -l info -s s3
INFO[0000] loading data                                  region=us-east-1 service=s3
INFO[0000] processing data                               region=us-east-1 service=s3
INFO[0019] finished processing data                      region=us-east-1 service=s3
INFO[0019] all data loaded
INFO[0019] all rows processed
INFO[0019] writing 73 rows to inventory.csv

________________________________________________________
Executed in   19.95 secs   fish           external
   usr time  278.74 millis  741.00 micros  278.00 millis
   sys time  112.74 millis  259.00 micros  112.48 millis
```

**After:**
```
time ./awsinventory -r us-east-1 -l info -s s3
INFO[0000] loading data                                  region=us-east-1 service=s3
INFO[0001] processing data                               region=us-east-1 service=s3
INFO[0001] finished processing data                      region=us-east-1 service=s3
INFO[0001] all data loaded
INFO[0001] all rows processed
INFO[0001] writing 73 rows to inventory.csv

________________________________________________________
Executed in    1.81 secs   fish           external
   usr time  583.28 millis  820.00 micros  582.46 millis
   sys time  158.53 millis  270.00 micros  158.26 millis
```