### PR TITLE
Always enable AWS shared configuration file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 ![GitHub release](https://img.shields.io/github/release/manywho/awsinventory.svg)
 
-AWS Inventory is a command line tool written in Go to fetch data from AWS and use it to generate a FedRAMP compliant inventory of your assets
+AWS Inventory is a command line tool written in Go to fetch data from AWS and use it to generate a FedRAMP compliant inventory of your assets.
 
 ## FedRAMP Compliance
-AWS Inventory aims to output a CSV in accordance to the [FedRAMP inventory template](https://www.fedramp.gov/assets/resources/templates/SSP-A13-FedRAMP-Integrated-Inventory-Workbook-Template.xlsx) found [here](https://www.fedramp.gov/templates/)
+AWS Inventory aims to output a CSV in accordance to the [FedRAMP inventory template](https://www.fedramp.gov/assets/resources/templates/SSP-A13-FedRAMP-Integrated-Inventory-Workbook-Template.xlsx) found [here](https://www.fedramp.gov/templates/).
 
 ## Usage
 
-To use awsinventory, simply download the [latest release](https://github.com/manywho/awsinventory/releases/latest) for your system, make the binary executable, then call it, passing any configuration flags. It uses the AWS SDK for Go to create a session from the shared credentials file (`~/.aws/credentials`). This file is usually generated using the AWS CLI
+To use awsinventory, simply download the [latest release](https://github.com/manywho/awsinventory/releases/latest) for your system, make the binary executable, then call it, passing any configuration flags. It uses the AWS SDK for Go to create a session based on the [default credential provider chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials), including `~/.aws/credentials` and `~/.aws/config`.
 
 ```sh
 # Example for Linux 64-bit
 wget -O awsinventory  https://github.com/manywho/awsinventory/releases/download/$VERSION/awsinventory-$VERSION-linux-amd64
 chmod 700 awsinventory
 
-# Build an inventory of services in the EU London AWS region
+# Build an inventory of services in the Europe (London) AWS region
 ./awsinventory --regions eu-west-2
 ```
 
@@ -39,7 +39,7 @@ Usage of ./awsinventory:
 ## Development
 
 ### Building
-The provided `Makefile` has a build target to handle building the binary
+The provided `Makefile` has a build target to handle building the binary.
 
 ```sh
 # Build the binary in the current directory
@@ -47,7 +47,7 @@ make build
 ```
 
 ### Testing
-The `Makefile` has 2 targets for local testing, `test` and `test-full`
+The `Makefile` has 2 targets for local testing: `test` and `test-full`.
 
 ```sh
 # Run tests

--- a/internal/awsdata/clients.go
+++ b/internal/awsdata/clients.go
@@ -63,87 +63,92 @@ type Clients interface {
 // DefaultClients holds the default methods for creating AWS service clients
 type DefaultClients struct{}
 
+// Default session options
+var sess = session.Must(session.NewSessionWithOptions(session.Options{
+	SharedConfigState: session.SharedConfigEnable,
+}))
+
 // GetCloudFrontClient returns a new CloudFront client for the given region
 func (c DefaultClients) GetCloudFrontClient(region string) cloudfrontiface.CloudFrontAPI {
-	return cloudfront.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return cloudfront.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetCodeCommitClient returns a new CodeCommit client for the given region
 func (c DefaultClients) GetCodeCommitClient(region string) codecommitiface.CodeCommitAPI {
-	return codecommit.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return codecommit.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetDynamoDBClient returns a new DynamoDB client for the given region
 func (c DefaultClients) GetDynamoDBClient(region string) dynamodbiface.DynamoDBAPI {
-	return dynamodb.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return dynamodb.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetEC2Client returns a new EC2 client for the given region
 func (c DefaultClients) GetEC2Client(region string) ec2iface.EC2API {
-	return ec2.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return ec2.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetECRClient returns a new ECS client for the given region
 func (c DefaultClients) GetECRClient(region string) ecriface.ECRAPI {
-	return ecr.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return ecr.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetECSClient returns a new ECS client for the given region
 func (c DefaultClients) GetECSClient(region string) ecsiface.ECSAPI {
-	return ecs.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return ecs.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetElastiCacheClient returns a new ElastiCache client for the given region
 func (c DefaultClients) GetElastiCacheClient(region string) elasticacheiface.ElastiCacheAPI {
-	return elasticache.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return elasticache.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetElasticsearchServiceClient returns a new ElasticsearchService client for the given region
 func (c DefaultClients) GetElasticsearchServiceClient(region string) elasticsearchserviceiface.ElasticsearchServiceAPI {
-	return elasticsearchservice.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return elasticsearchservice.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetELBClient returns a new ELB client for the given region
 func (c DefaultClients) GetELBClient(region string) elbiface.ELBAPI {
-	return elb.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return elb.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetELBV2Client returns a new ELBV2 client for the given region
 func (c DefaultClients) GetELBV2Client(region string) elbv2iface.ELBV2API {
-	return elbv2.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return elbv2.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetIAMClient returns a new IAM client for the given region
 func (c DefaultClients) GetIAMClient(region string) iamiface.IAMAPI {
-	return iam.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return iam.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetKMSClient returns a new KMS client for the given region
 func (c DefaultClients) GetKMSClient(region string) kmsiface.KMSAPI {
-	return kms.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return kms.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetLambdaClient returns a new RDS client for the given region
 func (c DefaultClients) GetLambdaClient(region string) lambdaiface.LambdaAPI {
-	return lambda.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return lambda.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetRDSClient returns a new RDS client for the given region
 func (c DefaultClients) GetRDSClient(region string) rdsiface.RDSAPI {
-	return rds.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return rds.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetRoute53Client returns a new Route53 client for the given region
 func (c DefaultClients) GetRoute53Client(region string) route53iface.Route53API {
-	return route53.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return route53.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetS3Client returns a new S3 client for the given region
 func (c DefaultClients) GetS3Client(region string) s3iface.S3API {
-	return s3.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return s3.New(sess, &aws.Config{Region: aws.String(region)})
 }
 
 // GetSQSClient returns a new SQS client for the given region
 func (c DefaultClients) GetSQSClient(region string) sqsiface.SQSAPI {
-	return sqs.New(session.Must(session.NewSession()), &aws.Config{Region: aws.String(region)})
+	return sqs.New(sess, &aws.Config{Region: aws.String(region)})
 }


### PR DESCRIPTION
The underlying AWS Go SDK v1 does not automatically enable the shared configuration file
(e.g. `~/.aws/config`) by default like the AWS CLI and other SDKs. Enabling it requires a
lesser documented environment variable: `AWS_SDK_LOAD_CONFIG=1` as a workaround.

Enable this support by default to reduce confusion.